### PR TITLE
feat: cut Claude agent mailbox over to micro-status-mcp server

### DIFF
--- a/.claude.json
+++ b/.claude.json
@@ -111,6 +111,10 @@
       "env": {
         "KAGI_API_KEY": "5ZrJZMBybQz3XDq93B_nVKNAWvm7Ru9BbIyJAnBjc2c.SoGOe8ghHE1fhXLhMlV4p9HGdBskLfEeoNOr6UqP7O0"
       }
+    },
+    "micro-status": {
+      "type": "http",
+      "url": "http://127.0.0.1:7878/mcp"
     }
   },
   "projects": {
@@ -2075,7 +2079,7 @@
             "1": {
               "id": 1,
               "type": "text",
-              "content":""
+              "content": ""
             }
           }
         },

--- a/.claude/commands/inbox.md
+++ b/.claude/commands/inbox.md
@@ -1,19 +1,19 @@
 Check the agent mailbox for messages addressed to the current repo and process them.
 
-Run `~/.claude/bin/agent-msg list` to enumerate pending message files. If the output is `(empty)`, say so in one line and stop — do not invent work.
+Call the `list_messages` tool from the `micro-status` MCP server with:
 
-For each file shown:
+- `repo`: the basename of the current working directory (`basename "$PWD"`).
+- `include_read`: omit or set to `false`. Only unread messages should be processed.
 
-1. Read it from `~/.claude/agent-mailbox/$(basename "$PWD")/inbox/<filename>`. The frontmatter (`from`, `to`, `subject`, `ts`) tells you who sent it and why.
-2. Summarize the sender's request in one short sentence to the user.
-3. Decide what to do:
-   - If the message is purely informational, acknowledge and archive it.
-   - If it suggests a code change, treat it as a feature/bug request and act on it the same way you would a user request — investigate the referenced files, implement the change, and report back.
-   - If the request is unclear or would require destructive action, ask the user before proceeding.
-4. After processing, archive the file:
-   ```bash
-   mkdir -p ~/.claude/agent-mailbox/$(basename "$PWD")/read
-   mv ~/.claude/agent-mailbox/$(basename "$PWD")/inbox/<filename> ~/.claude/agent-mailbox/$(basename "$PWD")/read/
-   ```
+If the response has an empty `messages` array, say "no messages" in one line and stop — do not invent work.
 
-Process messages in filename order (timestamps sort lexicographically) so older messages are handled first.
+For each message in the response (`messages[]`), in order (oldest first; the list is already sorted):
+
+1. Summarize the sender's request in one short sentence to the user, including the `from`, `subject`, and `id`.
+2. Decide what to do based on the `body`:
+   - If the message is purely informational, acknowledge it and move on.
+   - If it suggests a code change, treat it as a feature/bug request and act on it the same way you would a direct user request — investigate the referenced files, implement the change, and report back.
+   - If the request is unclear or would require a destructive action, ask the user before proceeding.
+3. After you have handled the message (whether by acting on it or by acknowledging it), call the `mark_read` tool with the message's `id` so it does not appear in future `/inbox` runs.
+
+If the MCP server is unreachable, tell the user to start it with `micro-status-mcp serve` — do not fall back to reading files from `~/.claude/agent-mailbox/`.

--- a/.claude/commands/post-msg.md
+++ b/.claude/commands/post-msg.md
@@ -1,4 +1,4 @@
-Send a message to a Claude session running in another repo via the agent mailbox.
+Send a message to a Claude session running in another repo via the micro-status-mcp server.
 
 `$ARGUMENTS` is pipe-separated: `<to-repo> | <subject> | <body>`.
 
@@ -6,20 +6,17 @@ Send a message to a Claude session running in another repo via the agent mailbox
 - `<subject>` is a short one-line summary used in the receiving Claude's notification.
 - `<body>` is the actual message. Include concrete file paths with `path:line` references, function/symbol names, and what you want the recipient to do (investigate, implement, review, etc.).
 
-Parse the arguments by splitting on ` | ` (pipe surrounded by spaces). Trim whitespace from each part. Then invoke:
+Parse the arguments by splitting on ` | ` (pipe surrounded by spaces). Trim whitespace from each part.
 
-```bash
-~/.claude/bin/agent-msg post "<to-repo>" "<subject>" "<body>"
-```
+Then call the `post_message` tool from the `micro-status` MCP server with:
 
-Use a heredoc for the body if it contains quotes, backticks, or multiple lines:
+- `from`: the basename of the **current** working directory (the sender). Compute it from `$PWD`.
+- `to`: the `<to-repo>` parsed above.
+- `subject`: the `<subject>` parsed above.
+- `body`: the `<body>` parsed above (preserved verbatim, multi-line OK).
 
-```bash
-~/.claude/bin/agent-msg post "<to-repo>" "<subject>" - <<'EOF'
-<body>
-EOF
-```
-
-The command prints the path of the message file it wrote — include that in your response so the user can find it. If the recipient's tmux pane is registered (auto-registers on Claude session start when run in tmux), the message will also be typed into their prompt automatically; otherwise it sits in their inbox until they run `/inbox`.
+The tool returns `{id, notified, notify_error?}`. If `notified=true`, the recipient's tmux pane has been woken with `/inbox`. If `notified=false`, either the recipient isn't registered or their pane is gone — the message still sits in the recipient's inbox until they run `/inbox`. Include the returned `id` and `notified` flag in your response.
 
 If `$ARGUMENTS` is empty or doesn't contain at least two ` | ` separators, ask the user for the missing pieces before posting.
+
+If the MCP tool call fails because the server is unreachable, tell the user to start it with `micro-status-mcp serve` (typically in a dedicated tmux pane) — do not fall back to writing files anywhere.

--- a/.claude/hooks/session-env-setup.sh
+++ b/.claude/hooks/session-env-setup.sh
@@ -17,10 +17,24 @@ if [ -n "$TMUX" ]; then
   tmux set -g pane-border-format "#{pane_index}: #{pane_title}" 2>/dev/null
 fi
 
-# Register this pane in the agent mailbox so other Claude sessions can
-# tmux-send-keys notifications here. No-op outside tmux.
-if [ -n "$TMUX" ] && [ -x "$HOME/.claude/bin/agent-msg" ]; then
-  "$HOME/.claude/bin/agent-msg" register >/dev/null 2>&1 || true
+# Register this pane with the micro-status-mcp server so other Claude
+# sessions can tmux-send-keys notifications here. No-op outside tmux or
+# if the server isn't running. We resolve the binary explicitly because
+# the PATH-augmenting block below doesn't take effect until the next
+# session.
+if [ -n "$TMUX" ]; then
+  MSM_BIN=""
+  if command -v micro-status-mcp >/dev/null 2>&1; then
+    MSM_BIN="$(command -v micro-status-mcp)"
+  elif [ -x "$HOME/go/bin/micro-status-mcp" ]; then
+    MSM_BIN="$HOME/go/bin/micro-status-mcp"
+  fi
+  if [ -n "$MSM_BIN" ]; then
+    "$MSM_BIN" register \
+      --repo "$(basename "$PWD")" \
+      --pane "$(tmux display-message -p '#S:#I.#P')" \
+      >/dev/null 2>&1 || true
+  fi
 fi
 
 [ -z "$CLAUDE_ENV_FILE" ] && exit 0


### PR DESCRIPTION
## Summary

- Cut the Claude inter-session agent mailbox over to the new Go MCP server: https://github.com/srhoton/micro-status-mcp/pull/1
- Replaces filesystem-based `~/.claude/agent-mailbox/` markdown queue with a SQLite-backed daemon; keeps the tmux `send-keys` wake-up.
- Companion to the micro-status-mcp PR — both need to land for the new flow to work end-to-end.

## What changed

| File | Change |
|---|---|
| `.claude/hooks/session-env-setup.sh` | Replace `agent-msg register` with a `micro-status-mcp register --repo --pane` call. Falls back to `$HOME/go/bin/micro-status-mcp` if `command -v` can't find it yet (the PATH-augmenting block lower in the script doesn't take effect until the next session). |
| `.claude/commands/post-msg.md` | Rewrite to invoke the MCP `post_message` tool with `from = basename "$PWD"`. Parses the same `to \| subject \| body` arg format as before. |
| `.claude/commands/inbox.md` | Rewrite to call MCP `list_messages` + `mark_read` against the running server. No more `mv` into `read/`. |
| `.claude.json` | Add `mcpServers.micro-status` HTTP entry pointing at `http://127.0.0.1:7878/mcp`. |

## Companion change

The old `~/.claude/bin/agent-msg` Bash script and the `~/.claude/agent-mailbox/` directory are left in place but no longer wired up. Both can be removed in a follow-up once the new server has been running stably for a while.

## Prereq

Install and run the MCP server before opening Claude sessions:

```bash
go install github.com/srhoton/micro-status-mcp/cmd/micro-status-mcp@latest
tmux new-window -n mcp 'micro-status-mcp serve'
```

## Test plan

- [ ] Merge https://github.com/srhoton/micro-status-mcp/pull/1 and `go install` the binary.
- [ ] Start `micro-status-mcp serve` in a dedicated tmux pane; confirm `curl http://127.0.0.1:7878/healthz` returns `ok`.
- [ ] Open two new Claude sessions in different tmux panes; confirm `micro-status-mcp sessions` lists both repos with their `session:window.pane` targets.
- [ ] In session A, run `/post-msg <repo-B> | test | hello`; confirm session B's pane receives a `/inbox` keystroke and the message can be processed via `/inbox`.
- [ ] Confirm `/inbox` marks messages read so they don't reappear on the next run.
- [ ] Kill and restart the server; confirm unread messages survive (SQLite durability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
