### PR TITLE
Add insights-driven workflow guards + cross-repo refresh

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,12 +37,21 @@
 ### Spec-Driven Implementation
 - When implementing from a spec/plan file, read the entire spec first and present a summary plan before making code changes. Make reasonable assumptions and note them rather than asking clarifying questions interactively.
 
+### Premise Verification
+- Before drafting any plan that names a service, file, library version, or commit SHA you don't already know exists in this repo, run `/verify-premise` (or invoke the `premise-verifier` agent directly). If the referenced target is not actually present or current, stop and report — do not build a plan against a phantom target.
+- Mandatory for: cross-service/cross-repo features, "look at how X uses Y" exploration that quotes a specific symbol, integration plans referencing a service the current repo has no obvious dependency on, and any task quoting a published library version or commit SHA.
+- Optional but encouraged: same check inside `/build-from-file` when reading a spec that references external services.
+
 ## Deployment Workflow
 
 - Standard end-to-end flow: implement → tests pass → self-review (`/review`) → commit with git notes → push → open PR → address review → ship through dev/stage/prod/demo via Port.io (`/shipit`).
 - **Port.io cache flicker**: action runs can oscillate between IN_PROGRESS and SUCCESS during polling. Poll the same state 2-3 times before reporting a final terminal state.
 - **Stale SHAs in deploys**: before triggering a deploy or terraform apply, confirm the target entity's `short_sha` matches the expected commit on origin. If misaligned, wait 30s and re-fetch — do not fire the action against a stale entity.
 - **Approval gate polling**: treat `approval_status = null` as pending, not failed. Retry up to 5x with 20s backoff before assuming the gate is broken.
+
+### New Lambda Repos
+- Every new Node/TypeScript Lambda project must include a `.npmrc` configured for the @fullbay AWS CodeArtifact registry before the first PR is opened. Missing this file is the single most common CI failure pattern (`npm install` returns 404 for `@fullbay/*` packages and the pipeline fails at the install step).
+- Any build/scaffold skill that creates a new Node-based Lambda must either generate the `.npmrc` or refuse to commit until one exists in the project root.
 
 ## Communication Style
 
@@ -56,6 +65,7 @@
 - For multi-file refactors, show only key snippets in the final summary, not every change.
 - For deploy/pipeline polling, report state changes as a compact table — not narrative prose.
 - This applies to user-visible output. Internal reasoning depth should remain high per the Thinking Depth section.
+- For any single output that would exceed roughly 150 lines or include large code/diff/log blocks (review findings, migration plans, scraped log dumps, multi-file refactor diffs): write the full content to `~/.claude/scratch/<repo-basename>/<topic>-<ISO8601>.md` (`mkdir -p` on demand) and post only a 3-bullet summary in chat with the path. Hard output-token caps have killed prior sessions mid-task; the scratch file is the durable artifact, chat is the index. Applies especially to reviewer output, deployment plans, and long log analyses.
 
 ## Code Quality
 - Prefer correct, complete implementations over minimal ones.
@@ -82,6 +92,7 @@ Adhere to the following guidelines when using tools:
 - Always use a **Research-First approach**: Before using any tool, conduct thorough research to understand the context and requirements. This ensures that you use the most appropriate tool for the task at hand. Never use an Edit-First approach. You should prefer making surgical edits to the codebase instead of rewriting whole files or doing large, sweeping changes.
 - Use **Reasoning Loops** very frequently. Don't be lazy and skip them. Reasoning loops are essential for ensuring the quality and accuracy of your work.
 - **LSP-first for symbol-level questions**: when working in a file type with an active LSP (Java via jdtls, TypeScript via typescript-lsp, Python via pyright), prefer LSP capabilities — find-references, go-to-definition, workspace-symbols, diagnostics — over grep + build cycles. LSPs distinguish overloads, inheritance, and imported vs local symbols where grep can't. Keep grep for text/comment/config searches and for languages without an active LSP (Terraform, shell, YAML).
+- **WebSearch / WebFetch for unfamiliar territory**: when debugging an error message you don't recognize, working with an unfamiliar library API, or looking up AWS service behavior, use WebSearch followed by WebFetch on the most authoritative result. Prefer official docs over Stack Overflow. The `/docs <topic>` skill wraps this pattern.
 
 ### Thinking Depth
 

--- a/.claude/commands/bughunt.md
+++ b/.claude/commands/bughunt.md
@@ -1,0 +1,45 @@
+Run a test-first bug hunt for the issue described in `$ARGUMENTS`. `$ARGUMENTS` may be a free-form description, a Linear/Jira ticket reference, or a path to a bug report file.
+
+**Critical rule: do not propose a fix until a failing test exists that fails for the right reason.** This skill exists because past sessions shipped speculative fixes when an early hypothesis went sideways; the failing test is the gate that forces evidence-based work.
+
+Process:
+
+1. **Evidence first — no hypotheses yet.**
+   - Read the bug description and identify the suspected component(s).
+   - Pull concrete evidence before guessing at the cause:
+     - Logs: use the `awslabs.cloudwatch-mcp-server` MCP tools (`describe_log_groups`, `execute_log_insights_query`) if AWS Lambda or CloudWatch is involved.
+     - Recent changes: `git log --oneline -20 -- <suspected paths>` and `gh pr list --state merged --search "<area>"` for recent PRs touching the area.
+     - Code: read the actual implementation, do not infer from names.
+   - State the evidence in one paragraph before forming a hypothesis. If you cannot find evidence, say so — do not invent it.
+
+2. **Reproduce, then write a failing test.**
+   - Identify the smallest test that would assert on the buggy behavior. Prefer the existing test framework in the repo (JUnit, Vitest, pytest, etc.) — do not introduce a new one.
+   - The test must assert on the actual buggy output, not on the absence of output. If the bug is "returns null when it should return X", the test asserts `result == X` and fails because `result == null`.
+   - Run the test and confirm it fails. Quote the failure message verbatim in your response.
+   - **If the test passes immediately, your hypothesis is wrong.** Re-investigate before continuing.
+
+3. **Implement the fix.**
+   - Now form the root-cause hypothesis based on evidence + failing test.
+   - Make the minimum change that turns the failing test green.
+   - Re-run the test (now passes) AND the full surrounding suite (no regressions).
+   - If the full suite has unrelated pre-existing failures, document them; do not chase them in this skill.
+
+4. **Write the root-cause document.**
+   - Write a short markdown file at `~/.claude/scratch/$(basename "$PWD")/bughunt-$(date -u +%Y-%m-%dT%H-%M-%SZ).md` with:
+     - **Symptom**: what was observed.
+     - **Evidence**: log lines, code paths, commit SHAs that led you to the cause.
+     - **Root cause**: one paragraph.
+     - **Fix**: file:line of the change and a one-line summary.
+     - **Regression test**: file:line of the new test.
+     - **Confidence**: high / medium / low + reason.
+   - `mkdir -p` the directory if it doesn't exist.
+
+5. **Surface in chat.**
+   - 3-bullet summary: symptom, root cause, fix path.
+   - Path to the scratch file.
+   - Do not paste the full writeup or the diff inline — the file is the durable artifact.
+
+Defaults / refusals:
+- If the user asks you to commit a fix without step 2 having produced a failing test, refuse and explain why.
+- If evidence-gathering surfaces that the bug is in a different repo than the current one, stop and report — do not chase it cross-repo without explicit instruction (`/refresh-other` + a follow-up bughunt in that repo is the right pattern).
+- If the CloudWatch MCP tools aren't available, fall back to asking the user for relevant log excerpts rather than guessing.

--- a/.claude/commands/inbox.md
+++ b/.claude/commands/inbox.md
@@ -17,3 +17,5 @@ For each message in the response (`messages[]`), in order (oldest first; the lis
 3. After you have handled the message (whether by acting on it or by acknowledging it), call the `mark_read` tool with the message's `id` so it does not appear in future `/inbox` runs.
 
 If the MCP server is unreachable, tell the user to start it with `micro-status-mcp serve` — do not fall back to reading files from `~/.claude/agent-mailbox/`.
+
+**Ack-style replies** (subject starts with `refresh complete` or `refresh blocked`): these are informational acks from a `/refresh-other` request this session sent earlier. Do not try to act on the SHA or run any git commands. Summarize the reply in one line to the user (e.g., "repo-b is now at main @ a1b2c3d" or "repo-b refused: dirty tree at src/foo.py"), then `mark_read` and continue.

--- a/.claude/commands/refresh-other.md
+++ b/.claude/commands/refresh-other.md
@@ -1,0 +1,48 @@
+Ask the Claude session in another repo to fast-forward that repo's checkout to its remote default branch (so this session can read fresh code there).
+
+`$ARGUMENTS` is `<repo-name>` — the basename of the target repo's working directory.
+
+If `$ARGUMENTS` is empty, ask the user which repo to refresh and stop.
+
+Steps:
+
+1. Determine the sender: `from = basename "$PWD"`.
+
+2. Call `mcp__micro-status__list_sessions` and confirm `<repo-name>` is in the returned list. If it isn't, tell the user "no Claude session is registered for `<repo-name>` — open Claude in that repo (inside tmux) first" and stop. Do not post a doomed message.
+
+3. Call `mcp__micro-status__post_message` with:
+   - `from`: the sender computed above.
+   - `to`: `<repo-name>`.
+   - `subject`: `refresh to default branch`
+   - `body` (verbatim — this is the recipe the receiving Claude will follow):
+
+     ```
+     Refresh this checkout to the remote default branch.
+
+     1. Run `git fetch origin --prune`.
+     2. Determine the default branch:
+        `default=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')`
+     3. If `git status --porcelain` is non-empty, STOP. Do NOT stash.
+        Post a reply via mcp__micro-status__post_message with:
+          from = <this repo's basename>
+          to   = <SENDER>
+          subject = "refresh blocked — dirty tree"
+          body    = the output of `git status --short`, plus a note that
+                    the human in this pane needs to clean/commit first.
+        Then tell the human in this pane what's dirty and wait for them.
+     4. Otherwise: `git checkout "$default" && git pull --ff-only origin "$default"`.
+     5. Capture the new HEAD: `sha=$(git rev-parse HEAD)`.
+     6. Post a reply via mcp__micro-status__post_message with:
+          from = <this repo's basename>
+          to   = <SENDER>
+          subject = "refresh complete"
+          body    = "<default-branch> @ <sha>"
+     ```
+
+   Substitute `<SENDER>` with the sender computed in step 1 so the receiver knows where to reply.
+
+4. The tool returns `{id, notified, notify_error?}`. Report both fields to the user. If `notified=true`, the recipient's pane has been woken with `/inbox` and will process the request on its next turn. If `notified=false`, the recipient will pick it up the next time someone runs `/inbox` in that session.
+
+5. Do not block waiting for the reply. The user can run `/inbox` later to see the `refresh complete` or `refresh blocked` ack.
+
+If the MCP tool call fails because the server is unreachable, tell the user to start it with `micro-status-mcp serve` (typically in a dedicated tmux pane).

--- a/.claude/hooks/session-env-setup.sh
+++ b/.claude/hooks/session-env-setup.sh
@@ -37,6 +37,13 @@ if [ -n "$TMUX" ]; then
   fi
 fi
 
+# Refresh origin so `git log origin/<branch>` is current. Backgrounded so
+# session start isn't blocked on slow network. Silent on failure (no
+# remote, no network, not a repo).
+if git -C "$PWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  ( git -C "$PWD" fetch origin --quiet --prune 2>/dev/null & disown ) || true
+fi
+
 [ -z "$CLAUDE_ENV_FILE" ] && exit 0
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Acts on the `/insights` gap analysis (2026-05-29). The analysis showed most insights suggestions were **already covered** by existing CLAUDE.md rules and skills (git-fetch-before-claiming-missing, the 8-stage shipit flow, count+moved Terraform rule, parallel reviewers, the multi-repo fleet, autonomous build skills). This PR adds the genuinely-new pieces, plus syncs the cross-repo refresh feature from the prior session that hadn't landed in dotfiles yet.

## CLAUDE.md

- **Premise Verification** — promotes `/verify-premise` to a documented pre-implementation gate for any plan naming a service/file/library-version/SHA not already known to exist. Targets the false-premise sessions (e.g. planning against `usr-contact-svc` when it isn't referenced).
- **New Lambda Repos** — requires `.npmrc` for @fullbay CodeArtifact before the first PR. This was the single most common CI failure (`npm install` 404 on `@fullbay/*`).
- **Output Token Discipline** — adds a rule to redirect >150-line or large code/diff/log output to `~/.claude/scratch/<repo>/<topic>-<ts>.md` and summarize in chat. Hard output-token caps killed prior sessions mid-task.
- Carries one pre-existing uncommitted line (WebSearch/WebFetch tool guidance) that was already in the live local config.

## hooks/session-env-setup.sh

- Backgrounded `git fetch origin --prune` on SessionStart (disowned so it never blocks session start). Pre-warms `git log origin/<branch>` to kill the stale-clone misfire class of friction.

## commands/bughunt.md (new)

- Test-first bug hunt skill: gather evidence → write a failing test → fix → root-cause writeup. The failing test is a hard gate; refuses to propose a fix without one. Mirrors the rhythm that nailed the address-copy and cold-start-JWKS diagnoses.

## commands/refresh-other.md (new) + commands/inbox.md

- Cross-repo refresh trigger over the `micro-status` MCP server: from repo-A, ask the Claude session in repo-B to fast-forward to its remote default branch so repo-A's lookups read fresh code. Dirty trees **refuse and ask the human** (no surprise stash). `/inbox` learns to treat `refresh complete` / `refresh blocked` replies as informational acks.

## Test plan

Smoke-tested locally:
- [x] SessionStart hook advances `.git/FETCH_HEAD` mtime in a git repo
- [x] SessionStart hook exits 0 silently in a non-git dir
- [x] CLAUDE.md sections present; `/bughunt` + `/refresh-other` show in command list

Needs real-world triggers:
- [ ] Premise Verification fires on a phantom-service planning request
- [ ] `.npmrc` generated when scaffolding a new Node Lambda
- [ ] `/bughunt` enforces failing-test-before-fix on a real bug
- [ ] Long-output redirect on a large `/reviewit` run
- [ ] `/refresh-other` round-trip across two tmux panes (happy + dirty-tree + unknown-recipient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
