### PR TITLE
Remove AWS labs MCP servers superseded by AWS plugins

### DIFF
--- a/.claude.json
+++ b/.claude.json
@@ -50,59 +50,6 @@
         "GITHUB_PERSONAL_ACCESS_TOKEN": ""
       }
     },
-    "awslabs.terraform-mcp-server": {
-      "command": "uvx",
-      "args": [
-        "awslabs.terraform-mcp-server@latest"
-      ],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false,
-      "autoApprove": []
-    },
-    "awslabs.aws-documentation-mcp-server": {
-      "command": "uvx",
-      "args": [
-        "awslabs.aws-documentation-mcp-server@latest"
-      ],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR",
-        "AWS_DOCUMENTATION_PARTITION": "aws"
-      },
-      "disabled": false,
-      "autoApprove": []
-    },
-    "aws-knowledge-mcp-server": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://knowledge-mcp.global.api.aws"
-      ]
-    },
-    "awslabs.aws-api-mcp-server": {
-      "command": "uvx",
-      "args": [
-        "awslabs.aws-api-mcp-server@latest"
-      ],
-      "env": {
-        "AWS_REGION": "us-east-1"
-      },
-      "disabled": false,
-      "autoApprove": []
-    },
-    "awslabs.cloudwatch-mcp-server": {
-      "autoApprove": [],
-      "disabled": false,
-      "command": "uvx",
-      "args": [
-        "awslabs.cloudwatch-mcp-server@latest"
-      ],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "transportType": "stdio"
-    },
     "Kagi": {
       "command": "uvx",
       "args": [


### PR DESCRIPTION
## Summary

Removes the standalone awslabs MCP servers from `.claude.json`. They're superseded by the `aws-core@agent-toolkit-for-aws` and `aws-agents` plugins, which provide AWS API access (`call_aws`/`run_script`), documentation, and knowledge through their bundled MCP servers plus a broad skill set (CDK, CloudFormation, serverless, observability, data-analytics, etc.). The standalone servers were showing as disconnected.

## Removed from `mcpServers`

- `aws-knowledge-mcp-server`
- `awslabs.aws-api-mcp-server`
- `awslabs.aws-documentation-mcp-server`
- `awslabs.cloudwatch-mcp-server`
- `awslabs.terraform-mcp-server`

## Kept

`Atlassian`, `Github`, `Kagi`, `micro-status`.

## Notes

- Mirrors the same removal already applied to the live local `~/.claude.json`, so a future dotfiles→local sync won't re-add them.
- Diff is surgical: 53 deletions, 0 insertions. Re-serialized with `ensure_ascii=False` to avoid escaping the file's existing non-ASCII history content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
