### PR TITLE
Add stale-PR reminder on PR creation

### DIFF
--- a/.claude/bin/stale-prs
+++ b/.claude/bin/stale-prs
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# stale-prs — list open PRs in the current repo that are being ignored.
+#
+# Prints open PRs that are:
+#   - not drafts
+#   - not authored by the current gh user
+#   - stale: no activity (updatedAt) in more than N days (default 3)
+#
+# One line per PR: "#<num> <title> — <age>d stale, @<author> — <url>".
+# Silent (no output) and exit 0 on any error condition: gh missing, not a
+# repo, not authenticated, or nothing qualifying. This makes it safe to
+# call from a hook — it can never disrupt a session.
+#
+# Usage: stale-prs [DAYS]
+
+set -euo pipefail
+DAYS="${1:-3}"
+
+command -v gh >/dev/null 2>&1 || exit 0
+# Must be inside a GitHub repo with a resolvable remote.
+gh repo view --json nameWithOwner >/dev/null 2>&1 || exit 0
+
+ME="$(gh api user --jq .login 2>/dev/null || true)"
+
+PRS_JSON="$(gh pr list --state open --limit 100 \
+  --json number,title,author,updatedAt,isDraft,url 2>/dev/null || true)"
+[ -z "$PRS_JSON" ] && exit 0
+
+DAYS="$DAYS" ME="$ME" python3 - "$PRS_JSON" <<'PY'
+import sys, json, os, datetime
+
+try:
+    data = json.loads(sys.argv[1] or "[]")
+except (ValueError, IndexError):
+    sys.exit(0)
+
+me = os.environ.get("ME", "")
+try:
+    days = int(os.environ.get("DAYS", "3"))
+except ValueError:
+    days = 3
+
+now = datetime.datetime.now(datetime.timezone.utc)
+threshold = now - datetime.timedelta(days=days)
+
+rows = []
+for pr in data:
+    if pr.get("isDraft"):
+        continue
+    login = (pr.get("author") or {}).get("login", "")
+    if me and login == me:
+        continue
+    try:
+        updated = datetime.datetime.fromisoformat(pr["updatedAt"].replace("Z", "+00:00"))
+    except (KeyError, ValueError):
+        continue
+    if updated >= threshold:
+        continue
+    age = (now - updated).days
+    rows.append((age, pr.get("number"), pr.get("title", ""), login, pr.get("url", "")))
+
+rows.sort(reverse=True)  # most-stale first
+for age, num, title, login, url in rows:
+    print(f"  #{num} {title} — {age}d stale, @{login} — {url}")
+PY

--- a/.claude/commands/stale-prs.md
+++ b/.claude/commands/stale-prs.md
@@ -1,0 +1,16 @@
+List open PRs in the current repo that are being ignored — not yours, not drafts, and with no activity in more than N days.
+
+`$ARGUMENTS` is an optional day threshold (default `3`). E.g. `/stale-prs` uses 3 days; `/stale-prs 7` uses 7.
+
+Run the existing helper:
+
+```bash
+~/.claude/bin/stale-prs ${ARGUMENTS:-3}
+```
+
+Then:
+
+- If it prints lines, surface them to the user verbatim under a short header like "Stale PRs in <repo> (no activity >Nd):". Each line is already formatted as `#<num> <title> — <age>d stale, @<author> — <url>`, sorted most-stale first.
+- If it prints nothing, the exit was clean — tell the user there are no stale PRs (or that this isn't a GitHub repo / `gh` isn't authenticated, if that's the likely cause). Do not invent results.
+
+This is the same query the `pr-stale-check.sh` PostToolUse hook runs automatically after `gh pr create`; this command just lets you check on demand without opening a PR.

--- a/.claude/hooks/pr-stale-check.sh
+++ b/.claude/hooks/pr-stale-check.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# pr-stale-check.sh - PostToolUse hook for Claude Code (matcher: Bash)
+#
+# After a `gh pr create` command runs, surface OTHER teams' open PRs in
+# the same repo that have gone stale (no activity >3 days), so they don't
+# keep getting ignored. Delegates the query to ~/.claude/bin/stale-prs.
+#
+# Reads tool input JSON from stdin. Emits a PostToolUse additionalContext
+# JSON payload when there are stale PRs; otherwise stays silent. Always
+# exits 0 — this is a reminder, never a blocker.
+#
+
+INPUT=$(cat)
+
+# Extract the command. Read both `tool_input.command` (current docs) and
+# `input.command` (what the other hooks on this machine use) so this works
+# regardless of payload version.
+COMMAND=$(printf '%s' "$INPUT" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print((d.get('tool_input') or d.get('input') or {}).get('command',''))" \
+  2>/dev/null)
+
+# Only act on PR-creation commands; pass through everything else.
+echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b' || exit 0
+
+STALE="$("$HOME/.claude/bin/stale-prs" 3 2>/dev/null || true)"
+[ -z "$STALE" ] && exit 0   # nothing stale → stay silent
+
+MSG="STALE PR REMINDER — other open PRs in this repo have had no activity in >3 days. Surface this list to the user verbatim:
+$STALE"
+
+MSG="$MSG" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": os.environ["MSG"],
+    }
+}))
+PY
+exit 0


### PR DESCRIPTION
## Summary

Other teams' PRs — new functionality, version-bump chores, dependabot bumps — frequently sit open and ignored because nobody is watching for them. This adds an automatic reminder: after any `gh pr create`, it surfaces open PRs in the same repo that are **not mine**, **not drafts**, and have had **no activity in >3 days** (stale by `updatedAt`), with title + age + author + URL so you can triage without opening GitHub.

## Files

- **`.claude/bin/stale-prs`** — queries `gh pr list --json`, filters (non-draft, not `@me`, `updatedAt` older than N days; default 3), prints `#num title — Nd stale, @author — url`, most-stale first. Silent and `exit 0` on every error path (not a repo, `gh` logged out, nothing stale) so it can never disrupt a session.
- **`.claude/hooks/pr-stale-check.sh`** — PostToolUse hook (matcher `Bash`). Greps the command for `gh pr create`, calls `stale-prs`, and returns the list via `hookSpecificOutput.additionalContext` so Claude relays it in its PR-creation summary. Parses both `tool_input.command` (current docs) and `input.command` (what this repo's other hooks use) for payload-version safety.

## Activation

The hook **wiring** lives in the local, untracked `~/.claude/settings.json` — consistent with how `pre-commit-checks.sh` and `format-on-edit.sh` are managed here (scripts tracked, wiring local). To activate from a fresh clone, add a `PostToolUse` matcher `Bash` running `bash ~/.claude/hooks/pr-stale-check.sh` with a 15s timeout. Takes effect on next Claude Code restart.

## Test plan

Verified locally against `~/git/architecture-decisions` (8 stale foreign PRs, up to 63 days old):

- [x] `stale-prs 3` lists foreign non-draft >3d-idle PRs, most-stale first, excludes my own
- [x] Hook emits valid `hookSpecificOutput.additionalContext` JSON on a `gh pr create` payload
- [x] Gating: `gh pr create` (both `tool_input`/`input` fields) triggers; `ls -la`, malformed JSON, and non-repo dirs stay silent + exit 0
- [ ] End-to-end: run `/trueup` in a repo with a stale foreign PR; confirm the post-creation message includes the list (needs Claude restart to load the settings wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
