### PR TITLE
Add environment SHA-drift check (shipit + /envdrift + startup hook)

### DIFF
--- a/.claude/bin/sha-relation
+++ b/.claude/bin/sha-relation
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# sha-relation — classify env SHAs against a base (dev) SHA using local git.
+#
+# Output, one per line (tab-separated): "<label>\t<sha>\t<RELATION>"
+#   MATCHES  — same commit as dev
+#   BEHIND   — ancestor of dev (normal pre-ship lag)
+#   AHEAD    — dev is an ancestor of it (env has commits dev lacks)
+#   DIVERGED — neither is an ancestor of the other
+#   UNKNOWN  — a SHA could not be resolved in the local repo
+#
+# Exit 0 always — this is a read-only classifier, never a blocker.
+#
+# Usage: sha-relation <dev_sha> <label:sha> [<label:sha> ...]
+
+set -uo pipefail
+DEV="${1:-}"; shift || true
+[ -z "$DEV" ] && exit 0
+
+# Outside a git repo, everything is UNKNOWN (but still emit rows so callers
+# get a complete table).
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  for p in "$@"; do
+    printf '%s\t%s\tUNKNOWN\n' "${p%%:*}" "${p#*:}"
+  done
+  exit 0
+fi
+
+# Best-effort fetch so 7-char short_shas resolve. Never block on it.
+git fetch origin --quiet --tags 2>/dev/null || true
+
+resolve() { git rev-parse --verify --quiet "${1}^{commit}" 2>/dev/null; }
+DEV_C="$(resolve "$DEV")"
+
+for pair in "$@"; do
+  label="${pair%%:*}"
+  sha="${pair#*:}"
+  c="$(resolve "$sha")"
+  if [ -z "$DEV_C" ] || [ -z "$c" ]; then
+    rel="UNKNOWN"
+  elif [ "$c" = "$DEV_C" ]; then
+    rel="MATCHES"
+  elif git merge-base --is-ancestor "$c" "$DEV_C" 2>/dev/null; then
+    rel="BEHIND"
+  elif git merge-base --is-ancestor "$DEV_C" "$c" 2>/dev/null; then
+    rel="AHEAD"
+  else
+    rel="DIVERGED"
+  fi
+  printf '%s\t%s\t%s\n' "$label" "$sha" "$rel"
+done

--- a/.claude/commands/envdrift.md
+++ b/.claude/commands/envdrift.md
@@ -1,0 +1,43 @@
+Report environment SHA drift for a Port.io stack: compare the commit deployed in `dev` against `qa`, `stage`, `prod`, and `demo`, and flag anything that isn't in sync.
+
+`$ARGUMENTS` is the stack name (e.g. `mig-start-mg-fun`). If empty, default to `basename "$PWD"` (the current repo). If you can't determine a stack, ask the user.
+
+**This is read-only. Never trigger a deploy from this command.** Use the Port MCP for entity reads; use local git only for ancestry classification.
+
+Procedure:
+
+1. Using the Port MCP `list_entities` on the `stack_environment_status` blueprint, read these entities and their `short_sha` property:
+   `<stack>-dev`, `<stack>-qa`, `<stack>-stage`, `<stack>-prod`, `<stack>-demo`.
+   - If the Port MCP is unavailable, say so and stop (suggest the user reconnect it).
+   - If `<stack>-dev` does not exist, report that `<stack>` doesn't appear to be a Port stack and stop.
+   - For any other env entity that doesn't exist, note it as "absent" and skip it.
+
+2. Capture `<stack>-dev`'s `short_sha` as the base (`DEV_SHA`).
+
+3. Classify the other envs against dev with the local git helper. Pass only the envs that exist:
+   ```bash
+   ~/.claude/bin/sha-relation <DEV_SHA> qa:<qa_sha> stage:<stage_sha> prod:<prod_sha> demo:<demo_sha>
+   ```
+   Each output line is `<label>\t<sha>\t<RELATION>` where RELATION is one of `MATCHES`, `BEHIND`, `AHEAD`, `DIVERGED`, `UNKNOWN`.
+
+4. Render a table:
+
+   ```
+   Env drift for <stack> (dev @ <DEV_SHA>):
+
+   | Env   | short_sha | vs dev        |
+   |-------|-----------|---------------|
+   | dev   | <sha>     | (base)        |
+   | qa    | <sha>     | BEHIND dev    |
+   | stage | <sha>     | MATCHES       |
+   | prod  | <sha>     | ⚠ AHEAD of dev |
+   | demo  | <sha>     | UNKNOWN       |
+   ```
+
+5. Verdict line beneath the table:
+   - All `MATCHES` → "✅ All environments in sync at `<DEV_SHA>`."
+   - Some `BEHIND`, none ahead/diverged → "ℹ️ N env(s) behind dev — normal if you haven't shipped yet."
+   - Any `AHEAD` or `DIVERGED` → loud flag, listing each: "⚠️ `<env>` is AHEAD of dev (running `<sha>` which dev does not contain) — dev is missing a commit that's live in `<env>`. Investigate before shipping."
+   - Any `UNKNOWN` → note that git couldn't resolve that SHA locally (the clone may be behind or this isn't the matching repo); it couldn't be classified.
+
+Keep the output compact — the table plus the verdict line, nothing more.

--- a/.claude/commands/shipit-batch.md
+++ b/.claude/commands/shipit-batch.md
@@ -4,6 +4,8 @@ You are a multi-stack deployment orchestrator. Ship the following stacks IN PARA
 
 **IMPORTANT: Use Port.io MCP tools for ALL operations. Do NOT use Bash for Port.io interactions.**
 
+**Exception (Step 0.5 only):** the environment-drift pre-flight may call local git via `~/.claude/bin/sha-relation` for read-only commit-ancestry classification. All deploy/promote/terraform/approval operations remain MCP-only.
+
 ---
 
 ## Step 0: Parse and Validate
@@ -20,6 +22,21 @@ You are a multi-stack deployment orchestrator. Ship the following stacks IN PARA
    mig-wor-mg-fun         | 9ff10f8
    mig-usr-mg-fun         | c872b3b
    ```
+
+---
+
+## Step 0.5: Environment Drift Pre-flight (per stack, non-interactive)
+
+For EACH stack, before dispatching its subagent:
+
+1. Read `short_sha` of `<stack>-qa/-stage/-prod/-demo` via `list_entities` (skip absent envs).
+2. Classify against dev: `~/.claude/bin/sha-relation {TARGET_SHA[<stack>]} qa:<sha> stage:<sha> prod:<sha> demo:<sha>`.
+3. Because the batch runs in parallel and can't pause interactively, apply **skip-and-report** instead of pausing:
+   - If any env is `AHEAD` or `DIVERGED`, mark that stack `FLAGGED` and DO NOT dispatch its subagent (Step 1). It will appear as `FLAGGED — <env> ahead of dev` in the final summary.
+   - `MATCHES` / `BEHIND` / `UNKNOWN` → the stack proceeds normally.
+4. Display a drift column in the launch table (e.g. `prod AHEAD ⚠`, or `clean`) so the user sees why a stack was held back.
+
+Only stacks NOT flagged are dispatched in Step 1.
 
 ---
 
@@ -80,14 +97,17 @@ shipit-batch complete: N stacks
 
 Stack                  | Outcome   | Failed step
 mig-start-mg-fun       | SUCCESS   | —
-mig-wor-mg-fun         | SUCCESS   | —
+mig-wor-mg-fun         | FLAGGED   | prod ahead of dev (not deployed)
 mig-usr-mg-fun         | FAILED    | 2/8 Promote Artifacts
 
 Failures:
 - mig-usr-mg-fun @ Promote Artifacts: <subagent failure summary>
+
+Flagged (skipped — drift):
+- mig-wor-mg-fun: prod is AHEAD of dev; investigate before shipping.
 ```
 
-If all SUCCESS, omit the "Failures" block.
+If all SUCCESS, omit the "Failures" and "Flagged" blocks. Include the "Flagged" block whenever any stack was held back in Step 0.5.
 
 ---
 

--- a/.claude/commands/shipit.md
+++ b/.claude/commands/shipit.md
@@ -2,6 +2,8 @@ You are a deployment pipeline orchestrator. Your job is to deploy stack `$ARGUME
 
 **IMPORTANT: Use Port.io MCP tools for ALL operations. Do NOT use Bash or other tools.**
 
+**Exception (Step 0.5 only):** the environment-drift pre-flight may additionally call local git via `~/.claude/bin/sha-relation` for read-only commit-ancestry classification. All deploy, promote, terraform, and approval operations remain MCP-only.
+
 Follow these steps exactly:
 
 ---
@@ -19,6 +21,31 @@ Deploying: {stack}
 SHA:       {TARGET_SHA}
 Pipeline:  QA → Promote → TF QA → Stage → TF Stage → Prod (auto-approve) → TF Prod → TF Demo
 ```
+
+---
+
+## Step 0.5: Environment Drift Pre-flight
+
+Before deploying, check where every environment currently sits relative to dev, and flag anything that isn't simply behind.
+
+1. Using `list_entities` on `stack_environment_status`, read the `short_sha` of `{stack}-qa`, `{stack}-stage`, `{stack}-prod`, `{stack}-demo` (Step 0 already captured `{stack}-dev` as `TARGET_SHA`). Skip any env entity that doesn't exist.
+2. Classify each against dev with the local git helper (this is the one allowed non-MCP call — see the exception above):
+   ```bash
+   ~/.claude/bin/sha-relation {TARGET_SHA} qa:<qa_sha> stage:<stage_sha> prod:<prod_sha> demo:<demo_sha>
+   ```
+   Each line is `<label>\t<sha>\t<RELATION>` where RELATION ∈ `MATCHES | BEHIND | AHEAD | DIVERGED | UNKNOWN`.
+3. Always display the drift table:
+   ```
+   Env drift (dev @ {TARGET_SHA}):
+   | Env   | short_sha | vs dev          |
+   |-------|-----------|-----------------|
+   | qa    | <sha>     | BEHIND dev      |
+   | stage | <sha>     | MATCHES         |
+   | prod  | <sha>     | ⚠ AHEAD of dev  |
+   | demo  | <sha>     | BEHIND dev      |
+   ```
+4. **Flag rule:** any env whose SHA != dev is drifted. `BEHIND` is the normal pre-ship state (that's why you're shipping) — note it and continue.
+5. **Pause rule:** if ANY env is `AHEAD` or `DIVERGED`, STOP before Step 1 and ask the user to confirm. An env ahead of dev means dev is missing a commit that's already live there — you may be about to ship the wrong baseline. Require an explicit "yes" to proceed. `UNKNOWN` (git couldn't resolve a SHA) → warn but do not hard-block; mention the clone may be behind.
 
 ---
 

--- a/.claude/hooks/sessionstart-envdrift.sh
+++ b/.claude/hooks/sessionstart-envdrift.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# sessionstart-envdrift.sh - SessionStart hook for Claude Code
+#
+# If the current repo is a deployable Port stack, inject an
+# additionalContext directive so Claude prints the env-drift table on its
+# first turn. The hook does NO network I/O — it only emits JSON — so
+# session start is never blocked; the Port MCP call happens when Claude
+# acts. Emits nothing (no directive) outside a git repo with a remote, or
+# on resume/compact (only fresh starts / explicit clear).
+#
+
+INPUT=$(cat)
+SOURCE=$(printf '%s' "$INPUT" | python3 -c \
+  "import sys,json; print(json.load(sys.stdin).get('source',''))" 2>/dev/null)
+
+# Only on a fresh start or explicit /clear — not resume/compact, so the
+# table doesn't re-print after every autocompact.
+case "$SOURCE" in
+  startup|clear|"") ;;
+  *) exit 0 ;;
+esac
+
+# Must be a git repo with an origin remote.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+git config --get remote.origin.url >/dev/null 2>&1 || exit 0
+
+STACK="$(basename "$PWD")"
+
+CTX="ENV-DRIFT STARTUP CHECK — this repo may be a deployable Port stack named '${STACK}'. On your first response, before addressing the user's request: using the Port MCP, look up the '${STACK}-dev' entity in the stack_environment_status blueprint. If it does NOT exist, do nothing and do not mention this check. If it DOES exist, follow the /envdrift procedure for stack '${STACK}' (read dev/qa/stage/prod/demo short_sha, run ~/.claude/bin/sha-relation, print the drift table), then continue with whatever the user asked. This is read-only — never deploy."
+
+CTX="$CTX" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": os.environ["CTX"],
+    }
+}))
+PY
+exit 0


### PR DESCRIPTION
## Summary

`/shipit` propagates `<stack>-dev`'s `short_sha` forward through qa → stage → prod → demo, but never looked at where the *other* environments currently sit. This adds cross-environment SHA-drift visibility: compare dev's commit against every other env and flag anything that isn't simply behind.

**Semantic nuance:** at ship time dev is normally *ahead* of the lower envs (that's why you're shipping), so "env differs from dev" is benign. The dangerous case is an env *ahead of* dev — running a commit dev doesn't contain (a regression, or an out-of-band hotfix that never landed in dev). The design flags every diff in the table but only *pauses* on ahead/diverged.

## Files

- **`bin/sha-relation`** (new) — pure-git classifier. Given dev's SHA + `label:sha` pairs, emits `MATCHES | BEHIND | AHEAD | DIVERGED | UNKNOWN` per env. Best-effort fetch so 7-char short_shas resolve; `exit 0` always.
- **`commands/envdrift.md`** (new) — `/envdrift <stack>` (defaults to `basename $PWD`). Reads the 5 env entities via Port MCP, classifies via `sha-relation`, prints a drift table + verdict. Read-only.
- **`commands/shipit.md`** — Step 0.5 pre-flight: always prints the drift table; `BEHIND` proceeds; `AHEAD`/`DIVERGED` pauses and asks before Step 1. Adds a scoped exception to the MCP-only rule (Step 0.5 may call local git via `sha-relation`; all deploy/promote/tf/approval ops stay MCP-only).
- **`commands/shipit-batch.md`** — same pre-flight per stack, but non-interactive: ahead/diverged stacks are **skipped** (not dispatched) and reported as `FLAGGED` in the summary rather than pausing.
- **`hooks/sessionstart-envdrift.sh`** (new) — SessionStart hook. In a git repo with a remote, injects an `additionalContext` directive so Claude prints the drift table for the current repo on the first turn (silent if no matching Port stack). Gated to `startup`/`clear` (not resume/compact); no network I/O in the hook itself.

## Why git ancestry

Port only exposes `short_sha` strings; distinguishing *behind* (normal) from *ahead* (regression risk) needs commit ancestry, which is local git. The Port reads stay in the prompt (Claude via MCP); only the classification is delegated to the script.

## Activation

The `settings.json` SessionStart wiring is **local-only** (settings isn't tracked here, same as the other hooks). To activate from a fresh clone, add a second entry to the `SessionStart` hooks array:
```json
{ "type": "command", "command": "bash ~/.claude/hooks/sessionstart-envdrift.sh", "timeout": 5000 }
```

## Test plan

Verified locally:
- [x] `sha-relation` classifier: BEHIND/MATCHES/AHEAD/UNKNOWN against real commits; 7-char short shas resolve; non-repo → all UNKNOWN, exit 0
- [x] SessionStart hook gating: startup-in-repo emits valid JSON with stack embedded; compact/resume/non-repo stay silent
- [x] settings.json valid; SessionStart runs both hooks
- [ ] `/envdrift <stack>` table render + `/shipit` Step 0.5 pause behavior — need Port MCP connected + a real session (Port reads can't be exercised offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
