### PR TITLE
Update subagent model definitions

### DIFF
--- a/.opencode/agents/adr-compliance-reviewer.md
+++ b/.opencode/agents/adr-compliance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Analyzes repositories for compliance with Fullbay's accepted Architecture Decision Records (ADRs). Loads ADRs from ~/git/architecture-decisions and checks against target codebase.
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny

--- a/.opencode/agents/code-quality-reviewer.md
+++ b/.opencode/agents/code-quality-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Reviews code quality, ensuring adherence to best practices, linting rules, and testing standards. Used in the SDLC review pipeline after functional review.
 mode: subagent
-model: anthropic/claude-opus-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny

--- a/.opencode/agents/functional-reviewer.md
+++ b/.opencode/agents/functional-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Verifies that generated code functionally accomplishes what was requested. Checks requirements completeness, correct behavior, and integration points.
 mode: subagent
-model: anthropic/claude-opus-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny

--- a/.opencode/agents/golang-agent.md
+++ b/.opencode/agents/golang-agent.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized subagent for generating Go projects and components following idiomatic Go patterns, with focus on concurrency, performance, and reliability
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # Golang Development Agent

--- a/.opencode/agents/java-quarkus-agent.md
+++ b/.opencode/agents/java-quarkus-agent.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized subagent for generating Java/Quarkus projects and components following best practices with Gradle, Spotless, and comprehensive testing
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # Java/Quarkus Development Agent

--- a/.opencode/agents/lambda-performance-reviewer.md
+++ b/.opencode/agents/lambda-performance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized performance reviewer for Java Quarkus applications running in AWS Lambda. Focuses on cold start optimization, native image readiness, memory sizing, and Lambda-specific patterns.
 mode: subagent
-model: anthropic/claude-opus-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny

--- a/.opencode/agents/performance-reviewer.md
+++ b/.opencode/agents/performance-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Reviews code for performance bottlenecks, inefficient algorithms, and optimization opportunities. Scopes to changed files and returns PASS/FAIL verdict.
 mode: subagent
-model: anthropic/claude-opus-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny

--- a/.opencode/agents/python-agent.md
+++ b/.opencode/agents/python-agent.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized subagent for generating Python projects and components with focus on AI/ML, following strict type checking, testing, and reproducibility best practices
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # Python Development Agent

--- a/.opencode/agents/react-agent.md
+++ b/.opencode/agents/react-agent.md
@@ -2,7 +2,7 @@
 description: Specialized subagent for generating React applications and components using functional patterns, TypeScript, Vite, and modern React best practices including module federation
 mode: subagent
 tools: {}
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # React Development Agent

--- a/.opencode/agents/routing-agent.md
+++ b/.opencode/agents/routing-agent.md
@@ -1,7 +1,7 @@
 ---
 description: SDLC orchestration agent that coordinates the complete software development lifecycle. Receives a project description, creates a formal plan, dispatches to language-specific subagents, orchestrates functional and code quality reviews with retry loops, and handles git commits, notes, and PR creation.
 mode: primary
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # Routing Subagent - SDLC Orchestration Agent

--- a/.opencode/agents/security-reviewer.md
+++ b/.opencode/agents/security-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Reviews code for security vulnerabilities, OWASP Top 10 issues, and security best practices. Scopes to changed files and returns PASS/FAIL verdict.
 mode: subagent
-model: anthropic/claude-opus-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny

--- a/.opencode/agents/terraform-agent.md
+++ b/.opencode/agents/terraform-agent.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized subagent for generating Terraform infrastructure as code following AWS best practices with proper state management, security, and testing
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # Terraform Infrastructure Agent

--- a/.opencode/agents/typescript-agent.md
+++ b/.opencode/agents/typescript-agent.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized subagent for generating TypeScript projects and components with strict type safety, comprehensive testing, and security-first approach
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 ---
 
 # TypeScript Development Agent

--- a/.opencode/agents/zach-style-code-reviewer.md
+++ b/.opencode/agents/zach-style-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Specialized code quality reviewer that provides feedback in the style of @zach-fullbay's PR reviews, covering Java backend services, TypeScript/React frontend applications, GraphQL schemas, and Terraform infrastructure.
 mode: subagent
-model: anthropic/claude-opus-4-20250514
+model: gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf
 permission:
   edit: deny
   write: deny


### PR DESCRIPTION
This PR updates the subagent model definitions in .opencode/agents/ to use gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf instead of sonnet or opus.
