### PR TITLE
chore: stop tracking compiled micro-status-mcp binary

### DIFF
--- a/.claude/bin/README.md
+++ b/.claude/bin/README.md
@@ -1,0 +1,24 @@
+# `~/.claude/bin`
+
+Helper executables on `PATH` for Claude Code workflows.
+
+## Tracked (shell scripts)
+
+- `agent-msg` — inter-Claude mailbox CLI (legacy filesystem mailbox).
+- `sha-relation` — classifies a deployed SHA as ahead/behind/equal for env-drift checks.
+- `stale-prs` — lists open PRs being ignored in the current repo.
+
+## Not tracked (compiled binary)
+
+- `micro-status-mcp` — the inter-agent mailbox MCP server. It is a large,
+  architecture-specific Go binary, so it is **git-ignored** rather than
+  committed. Build and install it from source:
+
+  ```bash
+  cd ~/git/micro-status-mcp
+  make build
+  cp -p bin/micro-status-mcp ~/.claude/bin/micro-status-mcp
+  # restart the server pane: micro-status-mcp serve
+  ```
+
+  Source repo: `github.com/srhoton/micro-status-mcp`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Compiled micro-status-mcp binary — built from ~/git/micro-status-mcp, not tracked.
+.claude/bin/micro-status-mcp


### PR DESCRIPTION
## Summary

Stops tracking the compiled `micro-status-mcp` binary that PR #41 added to the mirror, and documents how to build it instead.

A compiled, architecture-specific Mach-O binary (~18MB) doesn't belong in a config dotfiles repo: it's large, unreviewable in diffs, and goes stale on every rebuild of the source — which is exactly what happened when the inter-agent send-keys fix ([micro-status-mcp#2](https://github.com/srhoton/micro-status-mcp/pull/2)) rebuilt it.

## Changes
- `.gitignore` — ignore `.claude/bin/micro-status-mcp`
- `.claude/bin/README.md` — documents the tracked shell scripts and the `make build` + copy-to-`~/.claude/bin` flow for the binary

The shell scripts in `.claude/bin` (`agent-msg`, `sha-relation`, `stale-prs`) remain tracked. Source repo for the binary: `github.com/srhoton/micro-status-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
