### PR TITLE
Add TS compile gate + insights-driven CLAUDE.md guards

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,6 +13,7 @@
 ### Before Committing
 - Always run the full test suite before committing. If tests fail, fix them before proceeding.
 - For Java/Quarkus: run `./gradlew spotlessApply` before committing.
+- For TypeScript: verify `tsc --noEmit` passes (no `TS2741`/type-mismatch errors) before committing — prefer the project's `typecheck`/`build` script. When adding a field to a type/interface, update every companion object and JSON schema fixture (e.g. `*.v1.json`) in the same change so the compile stays green.
 - Before modifying dependencies (Gradle/npm), verify compatibility with current project versions. Do not move runtime dependencies to compileOnly without confirming they are not needed at build/augmentation time.
 - Before claiming a dependency or version doesn't exist, verify against the actual registry. A 404/failed install for `@fullbay/*` packages is almost always a stale CodeArtifact/SSO token, not a missing package — refresh the token and retry first.
 - Never suggest skipping or bypassing pre-commit hooks (`--no-verify`) to get around a failing install or check. Fix the underlying cause.
@@ -32,6 +33,7 @@
 
 ### AWS Commands
 - Before running any AWS CLI command against an environment, confirm the active SSO profile/account matches the intended target (`aws sts get-caller-identity` or check `AWS_PROFILE`, e.g. fb-demo-us-prod/Admin). Never assume the default profile is the right one.
+- Confirm the SSO session isn't expired before starting a long AWS/Terraform task — re-authenticate proactively (`aws sso login --profile <p>`) rather than discovering the expiry mid-run on a rejected call or blocked dependency install.
 
 ### Debugging
 - When diagnosing 401s/auth failures or other distributed-system errors, consider consumer-side causes (cold-start JWKS fetch blocking, concurrency races, client clock skew) in addition to the issuer/server side before settling on a root cause.
@@ -41,6 +43,13 @@
 - Do not change DMS `MaxFullLoadSubTasks` above the current value without explicit approval (known OOM risk).
 - Always run `terraform validate` and `terraform plan` before suggesting a commit.
 - Do not modify IAM roles tagged with governance policies — flag for human approval instead of attempting the change.
+- EventBridge **event-bus** targets reject `retry_policy` and `dead_letter_config` at the `PutTargets` API — omit those blocks for bus-to-bus routing (they're valid only on non-bus targets like Lambda/SQS).
+- Before validating target/permission blocks against AWS, pull the latest state instead of trusting a stale local clone — the API-accepted shape drifts, and a stale clone will generate blocks the live API rejects.
+
+### Descope FGA / Authorization Schemas
+- Validate FGA/ReBAC DSL against the Descope console before considering a schema change done — do not assume the generated syntax is accepted.
+- Common DSL syntax errors to avoid: no bare relation names on the RHS of a relation definition (qualify them), and no `//` comments in the DSL (the parser rejects them).
+- When managing FGA in Terraform, translate the ReBAC requirements into DSL and iterate through console validation rather than trusting a one-shot conversion.
 
 ### Spec-Driven Implementation
 - When implementing from a spec/plan file, read the entire spec first and present a summary plan before making code changes. Make reasonable assumptions and note them rather than asking clarifying questions interactively.

--- a/.claude/hooks/pre-commit-checks.sh
+++ b/.claude/hooks/pre-commit-checks.sh
@@ -70,10 +70,35 @@ elif [ -f "package.json" ]; then
     RUNNER="npm"
   fi
 
-  echo "Detected Node project (using $RUNNER). Running tests..." >&2
-  if ! "$RUNNER" test 2>&1 >&2; then
-    echo "ERROR: Tests failed. Fix test failures before committing." >&2
-    FAILED=1
+  # TypeScript compile gate — runs before tests since a type error (e.g. TS2741
+  # from a missing field) is a cheaper, earlier signal than a full test run.
+  # Only for actual TS projects (tsconfig.json present); prefer a project script
+  # over a bare tsc so path mappings / project references are respected.
+  if [ -f "tsconfig.json" ]; then
+    echo "Detected TypeScript project. Type-checking..." >&2
+    if grep -q '"typecheck"' package.json; then
+      TS_CMD=("$RUNNER" run typecheck)
+    elif grep -q '"build"' package.json; then
+      TS_CMD=("$RUNNER" run build)
+    elif command -v npx >/dev/null 2>&1; then
+      TS_CMD=(npx --no-install tsc --noEmit)
+    else
+      TS_CMD=()
+    fi
+    if [ "${#TS_CMD[@]}" -gt 0 ]; then
+      if ! "${TS_CMD[@]}" 2>&1 >&2; then
+        echo "ERROR: TypeScript compile (tsc --noEmit) failed. Fix type errors before committing." >&2
+        FAILED=1
+      fi
+    fi
+  fi
+
+  if [ $FAILED -eq 0 ]; then
+    echo "Detected Node project (using $RUNNER). Running tests..." >&2
+    if ! "$RUNNER" test 2>&1 >&2; then
+      echo "ERROR: Tests failed. Fix test failures before committing." >&2
+      FAILED=1
+    fi
   fi
 
 elif [ -f "go.mod" ]; then


### PR DESCRIPTION
## Summary

Closes the gaps surfaced by the **2026-06-21 `/insights` report** that weren't already handled earlier (sed/regex bulk edits, AWS SSO profile confirmation, and output-token discipline are already in `CLAUDE.md`, so they're not repeated here).

## TypeScript compile gate (`hooks/pre-commit-checks.sh`)

The Node branch ran only `$RUNNER test` — nothing ran `tsc --noEmit`, which is exactly how `TS2741` / missing-field errors reached review and CI. Now, for projects with a `tsconfig.json`, it type-checks **before** tests (cheaper, earlier signal):

- Prefers the project's `typecheck` script, then `build`, then falls back to `npx --no-install tsc --noEmit`.
- No-ops on JS-only repos (no `tsconfig.json`) and when no TS toolchain is available.
- A failed type-check blocks the commit and skips the test run.

Deliberately **not** added to `format-on-edit.sh` (post-edit): `tsc --noEmit` per-edit can take 10–30s on large repos, risks the 30s hook timeout, and is noisy. The commit gate covers where the errors actually escaped.

## CLAUDE.md additions

- **Before Committing** — verify `tsc --noEmit` for TS; update companion objects and `*.v1.json` schema fixtures when adding a field to a type.
- **Descope FGA / Authorization Schemas** (new) — validate DSL against the console before done; no bare relation names on a definition RHS; no `//` comments in the DSL; iterate ReBAC-in-Terraform through console validation.
- **Terraform Conventions** — `retry_policy`/`dead_letter_config` are rejected on EventBridge event-bus targets; pull latest state before validating target blocks against the live API.
- **AWS Commands** — confirm the SSO session isn't expired before long AWS/Terraform tasks.

## Verification
- `bash -n` + dry-runs: non-`git commit` passes through; Node dir without `tsconfig.json` skips tsc; passing `typecheck`+`test` → exit 0; failing `typecheck` → blocked (exit 1) before tests run.
- `git diff` confirms the hook change is only the tsc gate; exec bit stays `100755`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
